### PR TITLE
Cleanup installation, fix a couple bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
-/.cache/
-/.pytest_cache/
+/.cache
+/.pytest_cache
 
-/build/
-/dist/
-/*.egg-info/
+/build
+/dist
+/*.egg-info
 
 *.py[cdo]
 
 .DS_Store
-.idea/
+.idea
+.git
+.github
+
+venv*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@
 .DS_Store
 .idea
 .git
-.github
 
 venv*

--- a/labelpc/widgets/canvas.py
+++ b/labelpc/widgets/canvas.py
@@ -474,10 +474,10 @@ class Canvas(QtWidgets.QWidget):
             return False  # No need to move
         o1 = pos + self.offsets[0]
         if self.outOfPixmap(o1):
-            pos -= QtCore.QPoint(min(0, o1.x()), min(0, o1.y()))
+            pos -= QtCore.QPointF(min(0, o1.x()), min(0, o1.y()))
         o2 = pos + self.offsets[1]
         if self.outOfPixmap(o2):
-            pos += QtCore.QPoint(min(0, self.pixmap.width() - o2.x()),
+            pos += QtCore.QPointF(min(0, self.pixmap.width() - o2.x()),
                                  min(0, self.pixmap.height() - o2.y()))
         # XXX: The next line tracks the new position of the cursor
         # relative to the shape, but also results in making it
@@ -628,7 +628,7 @@ class Canvas(QtWidgets.QWidget):
                 return QtCore.QPoint(x3, min(max(0, y2), max(y3, y4)))
             else:  # y3 == y4
                 return QtCore.QPoint(min(max(0, x2), max(x3, x4)), y3)
-        return QtCore.QPoint(x, y)
+        return QtCore.QPointF(x, y)
 
     def intersectingEdges(self, point1, point2, points):
         """Find intersecting edges.
@@ -656,7 +656,7 @@ class Canvas(QtWidgets.QWidget):
                 x = x1 + ua * (x2 - x1)
                 y = y1 + ua * (y2 - y1)
                 m = QtCore.QPoint(int((x3 + x4) / 2), int((y3 + y4) / 2))
-                d = labelpc.utils.distance(m - QtCore.QPoint(x2, y2))
+                d = labelpc.utils.distance(m - QtCore.QPointF(x2, y2))
                 yield d, i, (x, y)
 
     # These two, along with a call to adjustSize are required for the

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ jsonschema-specifications==2023.12.1
 jupyter_core==5.5.1
 jupyterlab-widgets==3.0.9
 kiwisolver==1.4.5
--e git+https://github.com/bradylowe/labelpc.git@14c763e22f12ac1d58c9027301514b4eb00ac841#egg=labelpc
 laspy==1.7.1
 MarkupSafe==2.1.3
 matplotlib==3.8.2


### PR DESCRIPTION
# Cleanup Installation

## What
- Some people have trouble installing labelpc on python versions 3.xx due to a string comparison (i.e. "4" > "10")
- We want the installation to work as described in the README file
- Fixed a couple bugs related to float vs int
- Updated the .gitignore file

## How
- I removed a very buggy line from requirements.txt which was self-referencing
   - One of the dependencies of labelpc was an older version of labelpc....
- I replaced a couple instances of `QPoint` with `QPointF`

## Testing
- Clone the repository, checkout this branch
- Create and activate a new virtual environment
- Run `pip install -r requirements.txt`
- Run `pip install -e .`
- Run `labelpc` and play around with the app (load a LAS file and draw shapes)
